### PR TITLE
Fleshed out the Wiki url generation. Maps/Rares now use the item's ty…

### DIFF
--- a/TradeMacro.ahk
+++ b/TradeMacro.ahk
@@ -20,7 +20,18 @@
 	Send ^c
 	Sleep 250
 	DoParseClipboardFunction()
-	WikiUrl := "http://pathofexile.gamepedia.com/" Item.Name
+
+	if (Item.IsUnique) {
+		UrlAffix := Item.Name
+	} else if (Item.IsFlask) {
+		UrlAffix := Item.SubType
+	} else {
+		UrlAffix := Item.TypeName
+	}
+
+	UrlAffix := StrReplace(UrlAffix," ","_")
+	WikiUrl := "http://pathofexile.gamepedia.com/" UrlAffix
+
 	Run % WikiUrl
 	SuspendPOEItemScript = 0 ; Allow Item info to handle clipboard change event
 	return


### PR DESCRIPTION
…pe rather than name(e.g. 'Palace Map' instead of 'Twisted Sanctum'). Flasks will use 'Flask' since their specific type is not in the Item class.